### PR TITLE
Optimizations

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -35,6 +35,10 @@ pub fn unloadLevel() void {
     won = false;
 }
 
+fn checkWon() void {
+    lastwon = hasWon();
+}
+
 fn isSameSizeAsTargetStateWire(typ: Direction, idx: usize) bool {
     switch (typ) {
         .Horizontal => {
@@ -269,6 +273,7 @@ fn shiftColumn(idx: usize, amount: i32) void {
         while (i >= 0) : (i -= 1) {
             Level.state[@intCast(@as(i32, @intCast(i)) + amount)][idx] = Level.state[i][idx];
             Level.state[i][idx] = null;
+            checkWon();
 
             if (i == 0) {
                 break;
@@ -281,6 +286,7 @@ fn shiftColumn(idx: usize, amount: i32) void {
         for (1..Level.state[0].len) |x| {
             Level.state[@intCast(@as(i32, @intCast(x)) + amount)][idx] = Level.state[x][idx];
             Level.state[x][idx] = null;
+            checkWon();
         }
     }
 
@@ -325,6 +331,7 @@ fn shiftDiagDown(idx: usize, amount: i32) void {
 
             Level.state[xc][yc] = Level.state[xc - 1][yc - 1];
             Level.state[xc - 1][yc - 1] = null;
+            checkWon();
             xc -= 1;
             yc -= 1;
         }
@@ -339,6 +346,7 @@ fn shiftDiagDown(idx: usize, amount: i32) void {
             }
             Level.state[xc][yc] = Level.state[xc + 1][yc + 1];
             Level.state[xc + 1][yc + 1] = null;
+            checkWon();
             xc += 1;
             yc += 1;
         }
@@ -382,6 +390,7 @@ fn shiftDiagUp(idx: usize, amount: i32) void {
 
             Level.state[xc][yc] = Level.state[xc + 1][yc - 1];
             Level.state[xc + 1][yc - 1] = null;
+            checkWon();
             xc += 1;
             yc -= 1;
         }
@@ -396,6 +405,7 @@ fn shiftDiagUp(idx: usize, amount: i32) void {
             }
             Level.state[xc][yc] = Level.state[xc - 1][yc + 1];
             Level.state[xc - 1][yc + 1] = null;
+            checkWon();
             xc -= 1;
             yc += 1;
         }
@@ -420,6 +430,7 @@ fn shiftRow(idx: usize, amount: i32) void {
         while (i >= 0) : (i -= 1) {
             Level.state[idx][@intCast(@as(i32, @intCast(i)) + amount)] = Level.state[idx][i];
             Level.state[idx][i] = null;
+            checkWon();
 
             if (i == 0) {
                 break;
@@ -432,6 +443,7 @@ fn shiftRow(idx: usize, amount: i32) void {
         for (1..Level.state[0].len) |x| {
             Level.state[idx][@intCast(@as(i32, @intCast(x)) + amount)] = Level.state[idx][x];
             Level.state[idx][x] = null;
+            checkWon();
         }
     }
 
@@ -640,9 +652,6 @@ pub fn loop() bool {
                 shiftDiagDown(Level.diag_down_wires[selectedIndex] + 1, 1);
             }
         },
-    }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.up) or rl.isKeyPressed(.right) or rl.isKeyPressed(.left)) {
-        lastwon = hasWon();
     }
     renderWiresForDirectionWithSelectedIndex(.Vertical, selectedIndex, cursorState == .Vertical);
     renderWiresForDirectionWithSelectedIndex(.Horizontal, selectedIndex, cursorState == .Horizontal);

--- a/src/game.zig
+++ b/src/game.zig
@@ -17,6 +17,7 @@ var cursorState: Direction = .Vertical;
 
 var Level: types.LevelData = undefined;
 var level_loaded = false;
+var lastwon = false;
 
 pub fn levelUnloaded() bool {
     return !level_loaded;
@@ -640,6 +641,9 @@ pub fn loop() bool {
             }
         },
     }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.up) or rl.isKeyPressed(.right) or rl.isKeyPressed(.left)) {
+        lastwon = hasWon();
+    }
     renderWiresForDirectionWithSelectedIndex(.Vertical, selectedIndex, cursorState == .Vertical);
     renderWiresForDirectionWithSelectedIndex(.Horizontal, selectedIndex, cursorState == .Horizontal);
     renderWiresForDirectionWithSelectedIndex(.DiagonalUp, selectedIndex, cursorState == .DiagonalUp);
@@ -676,7 +680,7 @@ pub fn loop() bool {
         );
     }
 
-    if (rl.isKeyDown(.right_bracket) or hasWon()) {
+    if (rl.isKeyDown(.right_bracket) or lastwon) {
         if (!won) {
             won = true;
             assets.win_sfx.getOrLoad().play();

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,7 +48,7 @@ pub fn main() anyerror!void {
     const ending_speech = assets.endingSpeech.getOrLoad().sound;
 
     var tut_anim_timer: f32 = 0;
-    var tutorial_watched_at_least_once: bool = true;
+    var tutorial_watched_at_least_once: bool = false;
     var show_speedrun_timer: bool = false;
     var animFrames: i32 = 0;
     const tutorialAnim = try rl.loadImageAnim("resources/tutorial.gif", &animFrames);

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,7 +48,7 @@ pub fn main() anyerror!void {
     const ending_speech = assets.endingSpeech.getOrLoad().sound;
 
     var tut_anim_timer: f32 = 0;
-    var tutorial_watched_at_least_once: bool = false;
+    var tutorial_watched_at_least_once: bool = true;
     var show_speedrun_timer: bool = false;
     var animFrames: i32 = 0;
     const tutorialAnim = try rl.loadImageAnim("resources/tutorial.gif", &animFrames);
@@ -485,8 +485,9 @@ pub fn main() anyerror!void {
                             //     rl.Color.white,
                             // );
                         }
-                        if (lev.solved)
+                        if (lev.solved) {
                             assets.checkmark.getOrLoad().drawEx(img_anchor, 0.0, 1.0, rl.Color.white);
+                        }
                         if (!lev.locked and !lev.solved and rl.checkCollisionPointRec(mousePos, bounds) and rl.isMouseButtonPressed(.left)) {
                             std.debug.print("request {s}... and setting loc={s}\n", .{ lev.name, location.getInfo().name });
 


### PR DESCRIPTION
runs slightly faster by comparing checking wins only after moving wires instead of every update